### PR TITLE
Add avx512 flags to makevars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 src/*.o
 src/*.so
 src/*.dll
+src/whisper_cpp/*.o
 inst/dev
 inst/model-repository

--- a/src/Makevars
+++ b/src/Makevars
@@ -51,6 +51,12 @@ ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686 amd64))
 			PKG_CFLAGS   += -mavx2
 			PKG_CPPFLAGS += -mavx2
 		endif
+		
+		AVX512F_M := $(shell $(CPUINFO_CMD) | grep -iw 'AVX512F')
+		ifneq (,$(AVX512F_M))
+			PKG_CFLAGS   += -mavx512f
+			PKG_CPPFLAGS += -mavx512f
+		endif
 
 		FMA_M := $(shell $(CPUINFO_CMD) | grep -iw 'FMA')
 		ifneq (,$(FMA_M))


### PR DESCRIPTION
Present on recent Intel processors.