### PR TITLE
Add timeout note to whisper_download_model() docs

### DIFF
--- a/R/whisper.R
+++ b/R/whisper.R
@@ -195,6 +195,13 @@ whisper_download_model <- function(x = c("tiny", "tiny.en", "base", "base.en", "
   to <- file.path(model_dir, basename(url))
   download_failed  <- FALSE
   download_message <- "OK"
+  oldtimeout <- getOption("timeout")
+  if(length(oldtimeout) == 0 || is.na(as.integer(oldtimeout)) || as.integer(oldtimeout) < 60*10){
+    options(timeout = 60*10)
+    on.exit({
+      options(timeout = oldtimeout)
+    })
+  }
   if(overwrite || !file.exists(to)){
     dl <- suppressWarnings(try(
       utils::download.file(url = url, destfile = to, mode = "wb"),  

--- a/R/whisper.R
+++ b/R/whisper.R
@@ -123,6 +123,8 @@ whisper <- function(x, overwrite = FALSE, model_dir = getwd(), ...){
 #' \item{medium & medium.en: 1.5 GB, RAM required: ~2.6 GB. Multilingual and English only version.}
 #' \item{large-v1, large-v2, large-v3: 2.9 GB, RAM required: ~4.7 GB. Multilingual}
 #' }
+#' Note that the larger models may take longer than 60 seconds to download, so consider 
+#' increasing the timeout option in R via \code{options(timeout=120)}
 #' @param x the name of the model
 #' @param model_dir a path where the model will be downloaded to. Defaults to the current working directory
 #' @param repos character string with the repository to download the model from. Either

--- a/man/whisper_download_model.Rd
+++ b/man/whisper_download_model.Rd
@@ -52,6 +52,8 @@ Download a pretrained Whisper model. The list of available models are
 \item{medium & medium.en: 1.5 GB, RAM required: ~2.6 GB. Multilingual and English only version.}
 \item{large-v1, large-v2, large-v3: 2.9 GB, RAM required: ~4.7 GB. Multilingual}
 }
+Note that the larger models may take longer than 60 seconds to download, so consider 
+increasing the timeout option in R via \code{options(timeout=120)}
 }
 \examples{
 path <- whisper_download_model("tiny")


### PR DESCRIPTION
The default option for how long to allow files to download is only 60 seconds. This is not enough time for many users to download the larger models from huggingface. I added this note to the documentation to help them change the option.