### PR TITLE
change download message

### DIFF
--- a/R/whisper.R
+++ b/R/whisper.R
@@ -140,7 +140,7 @@ whisper <- function(x, overwrite = FALSE, model_dir = getwd(), ...){
 #'  \item{model: The model as provided by the input parameter \code{x}}
 #'  \item{file_model: The path to the file on disk where the model was downloaded to}
 #'  \item{url: The URL where the model was downloaded from}
-#'  \item{download_failed: A logical indicating if the download has failed or not due to internet connectivity issues}
+#'  \item{download_success: A logical indicating if the download has succeeded or not due to internet connectivity issues}
 #'  \item{download_message: A character string with the error message in case the downloading of the model failed}
 #' }
 #' @export

--- a/R/whisper.R
+++ b/R/whisper.R
@@ -214,7 +214,7 @@ whisper_download_model <- function(x = c("tiny", "tiny.en", "base", "base.en", "
   out <- data.frame(model = x,
                     file_model = to,
                     url = url,
-                    download_failed = download_failed,
+                    download_success = !download_failed,
                     download_message = download_message,
                     stringsAsFactors = FALSE)
   class(out) <- c("data.frame", "whisper_download")

--- a/inst/tinytest/test_download.R
+++ b/inst/tinytest/test_download.R
@@ -4,7 +4,7 @@ if(Sys.getenv("TINYTEST_CI", unset = "yes") == "yes"){
   ## Download a model
   path  <- whisper_download_model("tiny", overwrite = FALSE)
   expect_inherits(path, "data.frame")
-  expect_false(path$download_failed)
+  expect_true(path$download_success)
   
   ## Load the model
   model <- whisper("tiny")

--- a/man/whisper_download_model.Rd
+++ b/man/whisper_download_model.Rd
@@ -39,7 +39,7 @@ A data.frame with 1 row and the following columns:
  \item{model: The model as provided by the input parameter \code{x}}
  \item{file_model: The path to the file on disk where the model was downloaded to}
  \item{url: The URL where the model was downloaded from}
- \item{download_failed: A logical indicating if the download has failed or not due to internet connectivity issues}
+ \item{download_success: A logical indicating if the download has succeeded or not due to internet connectivity issues}
  \item{download_message: A character string with the error message in case the downloading of the model failed}
 }
 }


### PR DESCRIPTION
This jumped out at me - having 'download failed' - FALSE. The double negative just doesn't come across as very natural.

The expectation should be that it succeeds.

Easier to show directly in a PR than an issue. Feel free to close if you think otherwise.